### PR TITLE
Loosen version pinning on Flask and flask-rebar

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ if __name__ == "__main__":
         packages=["flask_rebar_auth0"],
         include_package_data=True,
         install_requires=[
-            "flask-rebar>=1.0.0,<2",
-            "Flask>=0.10,<2",
+            "flask-rebar>=1.0.0,<3",
+            "Flask>=0.10,<3",
             "requests>=2.20.0,<3",
             "python-jose>=3.0.1,<4",
             "cryptography>=3.2,<4",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
             "Flask>=0.10,<3",
             "requests>=2.20.0,<3",
             "python-jose>=3.0.1,<4",
-            "cryptography>=3.2,<4",
+            "cryptography",
         ],
         extras_require={
             "dev": [


### PR DESCRIPTION
As far as my testing has been able to determine, `flask-rebar-auth0` works fine with Flask and `flask-rebar` 2.x, but the current setup.py disallows installing them together. This PR just loosens the current restrictions to make installing this library with current Flask/`flask-rebar` possible.